### PR TITLE
Rename fork to PyYAML-ft and add a small paragraph to docs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -231,7 +231,7 @@ jobs:
 
         mkdir pyyaml
 
-        tar zxf ${{ steps.fetch_sdist.outputs.download-path }}/pyyaml*.tar.gz/pyyaml*.tar.gz --strip-components=1 -C pyyaml
+        tar zxf ${{ steps.fetch_sdist.outputs.download-path }}/pyyaml_ft*.tar.gz/pyyaml_ft*.tar.gz --strip-components=1 -C pyyaml
 
         cat << 'EOF' > build_config.toml
         [tool.cibuildwheel.config-settings]
@@ -397,7 +397,7 @@ jobs:
         python3 -m pip install -U --user ${{ matrix.cibw_version || 'cibuildwheel' }}
         mkdir pyyaml
         
-        tar zxf pyyaml*.tar.gz/pyyaml*.tar.gz --strip-components=1 -C pyyaml
+        tar zxf pyyaml_ft*.tar.gz/pyyaml_ft*.tar.gz --strip-components=1 -C pyyaml
         
         cat << 'EOF' > build_config.toml
         [tool.cibuildwheel.config-settings]
@@ -553,7 +553,7 @@ jobs:
         python -m pip install -U --user ${{ matrix.cibw_version || 'cibuildwheel' }}
         mkdir pyyaml
 
-        tar zxf pyyaml*.tar.gz/pyyaml*.tar.gz --strip-components=1 -C pyyaml
+        tar zxf pyyaml_ft*.tar.gz/pyyaml_ft*.tar.gz --strip-components=1 -C pyyaml
 
         cat << 'EOF' > build_config.toml
         [tool.cibuildwheel.config-settings]

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ clean:
 	${PYTHON} setup.py --with-libyaml clean -a
 	rm -fr \
 	    dist/ \
-	    lib/PyYAML.egg-info/ \
+	    lib/PyYAML_ft.egg-info/ \
 	    lib/yaml/__pycache__/ \
 	    tests/__pycache__/ \
 	    tests/legacy_tests/__pycache__/ \

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ in real-world applications. Our rationale with this fork is to implement support
 the free-threaded build, so that PyYAML can be tested with it by its users, even before
 the port is merged upstream.
 
-### Differences to upstream
+### Differences compared with upstream
 
 - This fork uses Cython 3.1.0b1 which supports the free-threaded build, but is still in
   beta. Its support for the free-threaded build is also still experimental.
@@ -60,7 +60,7 @@ the port is merged upstream.
           objs = yaml.load(yamlcode, Loader=yaml.CLoader)
           print(f"\t{objs=}")
       except Exception as e:
-          print(f"\tException occurred{e!s}")
+          print(f"\tException occurred: {e!s}")
 
   yaml.add_constructor("!dice", construct_dice, Loader=yaml.CLoader)
   load_dice()
@@ -77,7 +77,7 @@ the port is merged upstream.
   Thread MainThread
           objs=[Dice(1, 6), Dice(4, 4)]
   Thread Thread-1 (load_dice)
-          Exception occurredcould not determine a constructor for the tag '!dice'
+          Exception occurred: could not determine a constructor for the tag '!dice'
     in "<file>", line 1, column 3
   ```
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ the port is merged upstream.
     in "<file>", line 1, column 3
   ```
 
+  If you see new errors in multithreaded programs using `PyYAML-ft` that work with
+  `PyYAML`, you may need to add calls to `yaml.add_constructor` in your thread worker
+  function or worker initialization function.
+
 ### Python versions support
 
 Because PyYAML-ft is only aiming to exist for as long as upstream PyYAML

--- a/README.md
+++ b/README.md
@@ -1,7 +1,86 @@
-PyYAML
-======
+PyYAML-ft
+=========
 
-A full-featured YAML processing framework for Python
+A full-featured YAML processing framework for Python with support for free-threading
+
+## Why a fork?
+
+[PEP 703](https://peps.python.org/pep-0703/) introduced free-threaded Python as a
+separate build of CPython 3.13. Thread-safety issues that might have otherwise gone
+unnoticed are now much easier to trigger because of the absence of protection from
+the GIL. Also, because the free-threaded build is ABI-incompatible, extension
+modules need to be separate, free-threaded wheels and declare support for
+it.
+
+The PyYAML maintainers
+[decided to not port PyYAML to the free-threaded build](https://github.com/yaml/pyyaml/pull/830#issuecomment-2342475334)
+before the latter, along with Cython support for it, has been tested more extensively
+in real-world applications. Our rationale with this fork is to implement support for
+the free-threaded build, so that PyYAML can be tested with it by its users, even before
+the port is merged upstream.
+
+### Differences to upstream
+
+- This fork uses Cython 3.1.0b1 which supports the free-threaded build, but is still in
+  beta. Its support for the free-threaded build is also still experimental.
+- `add_constructor`, `add_representer` and `add_*resolver` now all use thread-local
+  registries, so you will have to explicitly register your custom constrcutors,
+  representers and resolvers in each thread. Here's a small test showcasing that:
+
+  ```python3
+  import io
+  import threading
+  import yaml
+
+
+  class Dice:
+      def __init__(self, first, second):
+          self.first = first
+          self.second = second
+      def __repr__(self):
+          return f"Dice({self.first}, {self.second})"
+
+
+  def construct_dice(constructor, node):
+      mapping = constructor.construct_mapping(node)
+      return Dice(**mapping)
+
+
+  def load_dice():
+      yamlcode = io.StringIO("""\
+  - !dice
+    first: 1
+    second: 6
+  - !dice
+    first: 4
+    second: 4
+  """)
+      print(f"Thread {threading.current_thread().name}")
+      try:
+          objs = yaml.load(yamlcode, Loader=yaml.CLoader)
+          print(f"\t{objs=}")
+      except Exception as e:
+          print(f"\tException occurred{e!s}")
+
+  yaml.add_constructor("!dice", construct_dice, Loader=yaml.CLoader)
+  load_dice()
+
+  t = threading.Thread(target=load_dice)
+  t.start()
+  t.join()
+  ```
+
+  Running the above script gives the following:
+
+  ```bash
+  ❯ python3.13t tmp/t.py
+  Thread MainThread
+          objs=[Dice(1, 6), Dice(4, 4)]
+  Thread Thread-1 (load_dice)
+          Exception occurredcould not determine a constructor for the tag '!dice'
+    in "<file>", line 1, column 3
+  ```
+
 
 ## Installation
 
@@ -41,13 +120,13 @@ To run the tests, type `python setup.py test`.
   IRC #pyyaml irc.libera.chat
 
 * Submit bug reports and feature requests to the
-  [PyYAML bug tracker](https://github.com/yaml/pyyaml/issues).
+  [PyYAML-ft bug tracker](https://github.com/Quansight-Labs/pyyaml/issues).
 
 ## License
 
 The PyYAML module was written by Kirill Simonov <xi@resolvent.net>.
 It is currently maintained by the YAML and Python communities.
 
-PyYAML is released under the MIT license.
+PyYAML-ft is released under the MIT license.
 
 See the file LICENSE for more details.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,33 @@ the port is merged upstream.
     in "<file>", line 1, column 3
   ```
 
+### Python versions support
+
+Because PyYAML-ft is only aiming to exist for as long as upstream PyYAML
+does not support the free-threaded build, we recommend that users only
+conditionally switch to PyYAML-ft.
+
+At this time, PyYAML-ft **only supports Python 3.13 and 3.13t (i.e. the
+free-threaded build of 3.13)**. To switch to it, you can do the following
+in your `requirements.txt` file:
+
+```requirements.txt
+...
+PyYAML; python_version < '3.13'
+PyYAML-ft; python_version >= '3.13'
+```
+
+If you're developing a library that depends on PyYAML and you're using
+`pyproject.toml` to specify your dependencies, you can do the following:
+
+```toml
+dependencies = [
+  ...,
+  "PyYAML; python_version<'3.13'",
+  "PyYAML-ft; python_version>='3.13'",
+]
+```
+
 
 ## Installation
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 
-NAME = 'PyYAML'
-VERSION = '7.0.0.dev0'
-DESCRIPTION = "YAML parser and emitter for Python"
+NAME = 'PyYAML-ft'
+VERSION = '0.1.0.dev0'
+DESCRIPTION = "YAML parser and emitter for Python with support for free-threading"
 LONG_DESCRIPTION = """\
 YAML is a data serialization format designed for human readability
 and interaction with scripting languages.  PyYAML is a YAML parser
@@ -13,13 +13,15 @@ supports standard YAML tags and provides Python-specific tags that
 allow to represent an arbitrary Python object.
 
 PyYAML is applicable for a broad range of tasks from complex
-configuration files to object serialization and persistence."""
+configuration files to object serialization and persistence.
+
+PyYAML-ft is a fork of PyYAML that adds support for free-threading."""
 AUTHOR = "Kirill Simonov"
 AUTHOR_EMAIL = 'xi@resolvent.net'
 LICENSE = "MIT"
 PLATFORMS = "Any"
 URL = "https://pyyaml.org/"
-DOWNLOAD_URL = "https://pypi.org/project/PyYAML/"
+DOWNLOAD_URL = "https://pypi.org/project/PyYAML-ft/"
 CLASSIFIERS = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
@@ -40,11 +42,11 @@ CLASSIFIERS = [
     "Topic :: Text Processing :: Markup",
 ]
 PROJECT_URLS = {
-   'Bug Tracker': 'https://github.com/yaml/pyyaml/issues',
-   'CI': 'https://github.com/yaml/pyyaml/actions',
+   'Bug Tracker': 'https://github.com/Quansight-Labs/pyyaml/issues',
+   'CI': 'https://github.com/Quansight-Labs/pyyaml/actions',
    'Documentation': 'https://pyyaml.org/wiki/PyYAMLDocumentation',
    'Mailing lists': 'http://lists.sourceforge.net/lists/listinfo/yaml-core',
-   'Source Code': 'https://github.com/yaml/pyyaml',
+   'Source Code': 'https://github.com/Quansight-Labs/pyyaml',
 }
 
 LIBYAML_CHECK = """

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 
 NAME = 'PyYAML-ft'
-VERSION = '0.1.0.dev0'
+VERSION = '7.0.0.dev0'
 DESCRIPTION = "YAML parser and emitter for Python with support for free-threading"
 LONG_DESCRIPTION = """\
 YAML is a data serialization format designed for human readability
@@ -16,11 +16,11 @@ PyYAML is applicable for a broad range of tasks from complex
 configuration files to object serialization and persistence.
 
 PyYAML-ft is a fork of PyYAML that adds support for free-threading."""
-AUTHOR = "Kirill Simonov"
-AUTHOR_EMAIL = 'xi@resolvent.net'
+AUTHOR = "Lysandros Nikolaou"
+AUTHOR_EMAIL = "lisandrosnik@gmail.com"
 LICENSE = "MIT"
 PLATFORMS = "Any"
-URL = "https://pyyaml.org/"
+URL = "https://github.com/Quansight-Labs/pyyaml/"
 DOWNLOAD_URL = "https://pypi.org/project/PyYAML-ft/"
 CLASSIFIERS = [
     "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
This PR includes all the necessary changes to upload this fork to
PyPI under the name PyYAML-ft. Additionally, it adds a new section
to the README explaining the rationale behind the fork and the
differences to the upstream project.